### PR TITLE
Update webpack configuration to use commonjs2

### DIFF
--- a/generators/app/templates/webpack.config.js
+++ b/generators/app/templates/webpack.config.js
@@ -6,7 +6,8 @@ module.exports = {
 
 	output: {
 		path: 'dist',
-		filename: 'index.js'
+		filename: 'index.js',
+		libraryTarget: 'commonjs2'
 	},
 
 	target: 'node',


### PR DESCRIPTION
In building https://github.com/ritterim/hubot-azure-alert-notifier we discovered that we needed to do this in the webpack configuration for the webpack output to work as expected with Hubot.